### PR TITLE
Remove the need for github-bot

### DIFF
--- a/.github/workflows/publish-signatures.yml
+++ b/.github/workflows/publish-signatures.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - 'TO_PUBLISH/**'
+      - 'SIGNATURES/**'
 
 jobs:
   publish-signatures:
@@ -29,11 +29,3 @@ jobs:
       - name: Publish signatures
         run: |
           uv run ./ghcr-signer.py publish
-
-      - name: Git commit published signatures
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add TO_PUBLISH PUBLISHED
-          git diff --staged --quiet || git commit -m "Move published signatures to the PUBLISHED folder"
-          git push

--- a/.github/workflows/verify-signatures.yml
+++ b/.github/workflows/verify-signatures.yml
@@ -3,7 +3,7 @@ name: Verify signatures
 on:
   pull_request:
     paths:
-      - 'TO_PUBLISH/**'
+      - 'SIGNATURES/**'
 
 jobs:
   verify-signatures:

--- a/PUBLISHED/README.md
+++ b/PUBLISHED/README.md
@@ -1,1 +1,0 @@
-Published signatures

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GHCR Signature Publisher
 
-Publish container signatures to the Github Container Registry (ghcr.io) when Github Personal Access Tokens (PATs) are disabled.
+This repository allows to publish container signatures to the Github Container Registry (ghcr.io) when Github Personal Access Tokens (PATs) are disabled.
 
 _Disabling PATs is considered a good security practice: these tokens aren't fine-grained and as such can give more privileges than intended to the bearer. Unfortunately, the Github Container Registry [doesn't provide](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry) any other mechanism of authentication._
 
@@ -11,27 +11,28 @@ Traditionally, container signatures are generated and published in one step usin
 
 The flow is as follows:
 
-1. Prepare the signatures using the `ghcr-signer.py` script
+1. Prepare the signatures locally
 2. Create a pull request, with the signatures
-3. The CI verifies the signatures are valid
-4. A workflow is triggered when the signatures are published to the `main` branch.
+3. The CI ensures signatures are valid
+4. The pull request is merged in the `main` branch
+5. A workflow is triggered, publishing the signatures to the registry.
 
 ### Preparing the signatures
 
-Generate a signature locally, without publishing it. Make sure to pass the image
+Generate signatures locally, without publishing it. Make sure to pass the image
 name and its hash, without labels:
 
 ```sh
 export IMAGE="ghcr.io/freedomofpress/dangerzone/dangerzone@sha256:<hash>"
-uv run ./ghcr-signer.py prepare "$IMAGE"
+uv run ./ghcr-signer.py prepare --recursive "$IMAGE"
 ```
 
-_You should also use `--recursive` in case of multi-arch images, and either pass a key via
-`--key` or `--sk` (in case of a hardware key)._
+_You should pass a key via `--key` or `--sk` (in case of a hardware key)._
 
 ### Publishing Signatures
 
-When the `main` branch is pushed, a workflow will:
+When the `main` branch is updated with new content inside the `SIGNATURES` folder,
+a workflow will:
 
-- Detect which hashes haven't been published yet
+- Detect the latest folder, based on its date
 - Attach signatures to the container registry using Github credentials

--- a/ghcr-signer.py
+++ b/ghcr-signer.py
@@ -14,10 +14,12 @@ from pathlib import Path
 
 import click
 
-ASSETS = Path("./assets")
+HERE = Path(__file__).parent
+ASSETS = HERE / Path("assets")
 COSIGN = ASSETS / "cosign"
 ORAS = ASSETS / "oras" / "oras"
 CRANE = ASSETS / "crane" / "crane"
+TRUSTED_PUB = HERE / "trusted.pub"
 
 LOCAL_REGISTRY = "127.0.0.1:7777"
 LOCAL_REPOSITORY = f"{LOCAL_REGISTRY}/local-dangerzone"
@@ -105,7 +107,7 @@ def save_blob_to(blob, destination):
 
 def cosign_verify(repository, on_local_repo=False):
     """Verifies that a signature is valid against a specified public key"""
-    cmd_verify = [str(COSIGN), "verify", "-d", "--key", "trusted.pub", repository]
+    cmd_verify = [str(COSIGN), "verify", "-d", "--key", str(TRUSTED_PUB), repository]
     env = os.environ.copy()
     if on_local_repo:
         env["COSIGN_REPOSITORY"] = LOCAL_REPOSITORY
@@ -144,7 +146,7 @@ def prepare_signature(
     image, signatures_dir, key, sk, recursive, date_folder=None, tag=False
 ):
     try:
-        signatures_path = Path(signatures_dir)
+        signatures_path = HERE / signatures_dir
         signatures_path.mkdir(parents=True, exist_ok=True)
 
         if not date_folder:
@@ -230,7 +232,7 @@ def push_and_verify(source_dir, on_local_repo=True, tag_latest=False):
     ensure_installed()
 
     # Get the latest active folder
-    source_path = Path(source_dir)
+    source_path = HERE / source_dir
     sorted_paths = sorted(list(source_path.iterdir()), reverse=True)
     if not sorted_paths:
         raise Exception("No valid path found")

--- a/ghcr-signer.py
+++ b/ghcr-signer.py
@@ -126,8 +126,8 @@ def cli():
 )
 @click.option("--key", help="Path to the signing key file")
 @click.option("--sk", is_flag=True, help="Use a hardware security key for signing")
-@click.option("--recursive", is_flag=True, default=True)
-def prepare(image, signatures_dir, key, sk, recursive):
+@click.option("--single-signature", is_flag=True, default=False)
+def prepare(image, signatures_dir, key, sk, single_signature):
     """Prepare the signatures for the given IMAGE and saves them to a local folder"""
     ensure_installed()
     with local_registry():
@@ -136,14 +136,14 @@ def prepare(image, signatures_dir, key, sk, recursive):
             signatures_dir,
             key,
             sk,
-            recursive,
+            single_signature,
             date_folder=None,
             tag=True,
         )
 
 
 def prepare_signature(
-    image, signatures_dir, key, sk, recursive, date_folder=None, tag=False
+    image, signatures_dir, key, sk, single_signature, date_folder=None, tag=False
 ):
     try:
         signatures_path = HERE / signatures_dir
@@ -196,7 +196,7 @@ def prepare_signature(
         if tag:
             (image_sig_dir / "LATEST").touch()
 
-        if recursive:
+        if not single_signature:
             crane_cmd = [str(CRANE), "manifest", image]
             process = subprocess_run(crane_cmd, check=True, capture_output=True)
             digests = [m["digest"] for m in json.loads(process.stdout)["manifests"]]
@@ -208,7 +208,7 @@ def prepare_signature(
                     signatures_dir,
                     key,
                     sk,
-                    recursive=False,
+                    single_signature=True,
                     date_folder=date_folder,
                     tag=False,
                 )


### PR DESCRIPTION
Instead of moving the files around when published, use date folders (with an isoformatted date) and only verify and publish the latest folder.

This will allow to strengthen the branch rules used on this repository.