### PR TITLE
Check all signatures

### DIFF
--- a/.github/workflows/publish-signatures.yml
+++ b/.github/workflows/publish-signatures.yml
@@ -13,14 +13,14 @@ jobs:
       packages: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
       - name: Install vendored dependencies
         run: |
           uvx mazette install
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/verify-signatures.yml
+++ b/.github/workflows/verify-signatures.yml
@@ -7,8 +7,8 @@ jobs:
   verify-signatures:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
       - name: Install vendored dependencies
         run: |
           uvx mazette install

--- a/.github/workflows/verify-signatures.yml
+++ b/.github/workflows/verify-signatures.yml
@@ -2,8 +2,6 @@ name: Verify signatures
 
 on:
   pull_request:
-    paths:
-      - 'SIGNATURES/**'
 
 jobs:
   verify-signatures:
@@ -17,4 +15,4 @@ jobs:
           ls -lah assets
       - name: Verify signatures
         run: |
-          uv run ./ghcr-signer.py verify
+          uv run ./ghcr-signer.py verify-local

--- a/SIGNATURES/README.md
+++ b/SIGNATURES/README.md
@@ -1,0 +1,4 @@
+This folder contains signatures, either to be published, or already published.
+
+When pushing the `main` branch, only the last folder (ordered by name) will be
+published to the ghcr.io registry.


### PR DESCRIPTION
Rather than checking only the last signature folder, check all the folders.

This enables to require the "Verify signatures" check as a prerequisite to merge Pull Requests.