### PR TITLE
adding linting to ci

### DIFF
--- a/.github/workflows/verify-signatures.yml
+++ b/.github/workflows/verify-signatures.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           ruff check
           ruff format --check
-          uvx yamllint@1.37.1
+          uvx yamllint@1.37.1 .
 
   verify-signatures:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes: #9 

I figured this would be the minimal change required to keep things lightweight.  i.e. no adding `pyproject.toml` to specify dev dependencies

Once this is merged, I'll add the lint job as a required check in branch protections.